### PR TITLE
Process ealstm

### DIFF
--- a/in_text/text_data_release.yml
+++ b/in_text/text_data_release.yml
@@ -153,7 +153,7 @@ process-description: >-
   meteorology to estimate water temperature, and 2)  an entity-aware long short-term memory network trained using lake temperature observations 
   and four lake-specific properties. Lake-specific properties and temperature obvservations were 
   aggregated from a variety of sources and cooperators for lakes across the US Midwest. Meteorological inputs for the contemporary period (1981-
-  2000) used by both modeling frameworks were downloaded from the North American Land Data Assimilation System (NLDAS, Mitchell et al 2004). Meteorological inputs for 
+  2000) used by both modeling frameworks were downloaded from the North American Land Data Assimilation System (NLDAS, Mitchell et al., 2004). Meteorological inputs for 
   future climate scenarios used only by the hydrodynamic model were downloaded from the USGS Geo Data Portal dataset "Dynamical Downscaling for   
   the Midwest and Great Lakes Basin" (https://www.sciencebase.gov/catalog/item/5b2d6121e4b040769c124c0c). This input data covers three different 
   time periods (1980-1999, 2040-2059, and 2080-2099) and is referred to as "GCM" throughout this data release. 
@@ -172,7 +172,7 @@ process-description: >-
   
   Lake temperature estimates were generated using an Entity-Aware Long Short-Term Memory network (EA-LSTM), as described by Kratzert et al., 2019.
   Temperature profiles were predicted for 82128 lakes in the North American continent from 1979 to 2022. The EA-LSTM network used daily
-  temperature observations from 7556 lakes. Inputs to the model were seven meteorological drivers derived from NLDAS for the time period 1979-2022,
+  temperature observations from 7556 lakes. Inputs to the model were seven meteorological drivers derived from NLDAS (Mitchell et al., 2004) for the time period 1979-2022,
   and four static lake attributes: latitude, longitude, surface area, and lake elevation above sea level. The data aggregation methods used to 
   assemble the temperature profile data and the lake attributes are described in Willard et al. 2022. This data release used these methods to
   aggregate additional cooperator data. This data release also used full temperature profiles for each sampling date rather than only using surface
@@ -180,8 +180,9 @@ process-description: >-
   
   To train the EA-LSTM, temperature observations were organized into 400 day long sequences. Successive sequences overlapped by 200 days. The mean
   squared error of the temperature predictions was used as a loss function. Predictions made during the first 100 days were not included in the loss
-  function. Sixty percent of the available observational data were used to train the EA-LSTM, twenty percent were used for validation during training
-  and hyperparameter selection, and twenty percent were used to evaluate the final model's performance. Data were split by lake to avoid data leakage.
+  function to allow time for the LSTM cell state to accurately represent the thermal state of the lake. Sixty percent of the available observational
+  data were used to train the EA-LSTM, twenty percent were used for validation during training and hyperparameter selection, and twenty percent were
+  used to evaluate the final model's performance. Data were split by lake to avoid data leakage.
   
   Lakes were discretized into a series of depth intervals. The top 10 meters of the lake were discretized into 0.5 m intervals. From 10 to 20 m, 1 m
   intervals were used. From 20 to 40 m, 2 m intervals were used. From 40 to 80 m, 5 m intervals were used. Observations were binned based on the

--- a/in_text/text_data_release.yml
+++ b/in_text/text_data_release.yml
@@ -27,6 +27,19 @@ cross-cites:
       Large-scale modeled contemporary and future water temperature estimates for 10,774 Midwestern U.S. Lakes
     pubdate: 2017
     link: http://dx.doi.org/10.1038/sdata.2017.53
+  -
+    authors: ["Frederik Kratzert","Daniel Klotz","Guy Shalev", "Günter Klambauer", "Sepp Hochreiter", "Grey Nearing"]
+    title: >-
+      Towards learning universal, regional, and local hydrological behaviors via machine learning applied to large-sample datasets
+    pubdate: 2019
+    form: publication
+    doi: 10.5194/hess-23-5089-2019
+  -
+    authors: ["Diederik P. Kingma", "Jimmy Ba"]
+    title: >-
+      Adam: A Method for Stochastic Optimization,
+    pubdate: 2014
+    link: https://doi.org/10.48550/arXiv.1412.6980
 
 process-date: !expr format(Sys.time(),'%Y%m%d')
 file-format: a single comma-delimited file and a single zipped shapefile
@@ -125,7 +138,8 @@ funding-credits: >-
 
 process-description: >-
   This dataset was generated using two modeling frameworks: 1) a lake hydrodynamic model that uses inputs of lake-specific properties and local 
-  meteorology to estimate water temperature, and 2) [LSTM description from Andy]. Lake-specific properties and temperature obvservations were 
+  meteorology to estimate water temperature, and 2)  an entity-aware long short-term memory network trained using lake temperature observations 
+  and four lake-specific properties. Lake-specific properties and temperature obvservations were 
   aggregated from a variety of sources and cooperators for lakes across the US Midwest. Meteorological inputs for the contemporary period (1981-
   2000) used by both modeling frameworks were downloaded from the North American Land Data Assimilation System (NLDAS, Mitchell et al 2004). Meteorological inputs for 
   future climate scenarios used only by the hydrodynamic model were downloaded from the USGS Geo Data Portal dataset "Dynamical Downscaling for   
@@ -144,7 +158,18 @@ process-description: >-
   written or summarized to the files included in this set of data. In addition, a set of 172 annual metrics summarizing different thermal properties
   of interest were derived from the daily temperature outputs for each lake.
   
-  [More description of LSTM from Andy]
+  Lake temperature estimates were generated using an Entity-Aware Long Short-Term Memory network (EA-LSTM), as described by Kratzert et al., 2019. The
+  EA-LSTM network was trained on daily temperature observations from 15512 lakes. Temperature observations were organized into 400 day long sequences.
+  Successive sequences overlapped by 200 days. The mean squared error of the temperature predictions was used as a loss function. Predictions made
+  during the first 100 days were not included in the loss function. Inputs to the model were seven meteorological drivers derived from NLDAS and four
+  static lake attributes: latitude, longitude, surface area, and lake elevation above sea level.
+  
+  Lakes were discretized into a series of depth intervals. The top 10 meters of the lake were discretized into 0.5 m intervals. From 10 to 20 m, 1 m
+  intervals were used. From 20 to 40 m, 2 m intervals were used. From 40 to 80 m, 5 m intervals were used. Observations were binned based on the
+  discretized depth interval into which the depth of the observation fell. The EA-LSTM was trained to predict one temperature per depth interval at
+  each time step. To allow temperature predictions at multiple depths, the number of outputs of the final fully connected layer was changed to equal
+  the number of depth intervals. The hidden layer size was 256. No dropout was used. The Adam optimizer (Kingma et al., 2015) was used with a learning
+  rate of 0.005. Early stopping was used to determine the optimal number of training epochs with a stopping patience of 50 epochs.
   
   Modeling environment information for both modeling frameworks are captured below.
   
@@ -154,7 +179,104 @@ process-description: >-
   forcats, version: 0.5.1; stringr, version: 1.4.0; dplyr, version: 1.0.8; purrr, version: 0.3.4; readr, version: 2.1.2; tidyr, version: 1.2.0; tibble, 
   version: 3.1.6; ggplot2, version: 3.3.5; tidyverse, version: 1.3.1; tarchetypes, version: 0.6.0; and targets, version: 0.12.0.
   
-  The LSTM data were generated using ... [Andy to add info]
+  The LSTM data were generated using open source tools available in the Python programming language (Python version 3.10.6). The computing platform for 
+  generating data and metadata was x86_64-apple-darwin20.6. Python packages loaded into this environment: 
+  _r-mutex=1.0.1=anacondar_1; aioeasywebdav=2.4.0=pyha770c72_0; aiohttp=3.8.1=py310h1961e1f_1; aiosignal=1.2.0=pyhd8ed1ab_0; amply=0.1.5=pyhd8ed1ab_0;
+  anyio=3.6.1=pyhd8ed1ab_1; appdirs=1.4.4=pyh9f0ad1d_0; appnope=0.1.3=pyhd8ed1ab_0; argon2-cffi=21.3.0=pyhd8ed1ab_0;
+  argon2-cffi-bindings=21.2.0=py310h1961e1f_2; arrow-cpp=9.0.0=py310h0687de5_2_cpu; asttokens=2.0.8=pyhd8ed1ab_0; async-timeout=4.0.2=pyhd8ed1ab_0;
+  async_generator=1.10=py_0; attmap=0.13.2=pyhd8ed1ab_0; attrs=22.1.0=pyh71513ae_1; aws-c-cal=0.5.11=hd2e2f4b_0; aws-c-common=0.6.2=h0d85af4_0;
+  aws-c-event-stream=0.2.7=hb9330a7_13; aws-c-io=0.10.5=h35aa462_0; aws-checksums=0.1.11=h0010a65_7; aws-sdk-cpp=1.8.186=h766a74d_3;
+  babel=2.10.3=pyhd8ed1ab_0; backcall=0.2.0=pyh9f0ad1d_0; backports=1.0=py_2; backports.functools_lru_cache=1.6.4=pyhd8ed1ab_0;
+  bcrypt=3.2.2=py310h6c45266_0; beautifulsoup4=4.11.1=pyha770c72_0; blas=2.116=mkl; blas-devel=3.9.0=16_osx64_mkl; bleach=5.0.1=pyhd8ed1ab_0;
+  bokeh=2.4.3=pyhd8ed1ab_3; boto3=1.24.69=pyhd8ed1ab_0; botocore=1.27.69=pyhd8ed1ab_0; brotli=1.0.9=h5eb16cf_7; brotli-bin=1.0.9=h5eb16cf_7;
+  brotlipy=0.7.0=py310h1961e1f_1004; bwidget=1.9.14=h694c41f_1; bzip2=1.0.8=h0d85af4_4; c-ares=1.18.1=h0d85af4_0;
+  ca-certificates=2022.9.14=h033912b_0; cachetools=5.2.0=pyhd8ed1ab_0; cairo=1.16.0=h904041c_1013; cartopy=0.20.3=py310he07f060_2;
+  cctools_osx-64=973.0.1=h3eff9a4_10; certifi=2022.9.14=pyhd8ed1ab_0; cffi=1.15.1=py310h96bbf6e_0; cftime=1.6.1=py310h1bbcd0e_0;
+  charset-normalizer=2.1.1=pyhd8ed1ab_0; clang=14.0.4=h694c41f_0; clang-14=14.0.4=default_h55ffa42_0; clang_osx-64=14.0.4=h3a95cd4_2;
+  clangxx=14.0.4=default_h55ffa42_0; clangxx_osx-64=14.0.4=he1dbc44_2; cloudpickle=2.2.0=pyhd8ed1ab_0; coin-or-cbc=2.10.8=hc8a182d_0;
+  coin-or-cgl=0.60.6=ha3c4b8c_2; coin-or-clp=1.17.7=hf0ee74e_2; coin-or-osi=0.108.7=hfef9e4d_2; coin-or-utils=2.11.6=h7a46149_2;
+  coincbc=2.10.8=0_metapackage; colorama=0.4.5=pyhd8ed1ab_0; colorcet=3.0.0=py_0; commonmark=0.9.1=py_0; compiler-rt=14.0.4=h7fcd477_0;
+  compiler-rt_osx-64=14.0.4=h6df654d_0; configargparse=1.5.3=pyhd8ed1ab_0; connection_pool=0.0.3=pyhd3deb0d_0; cryptography=37.0.4=py310h52c3658_0;
+  curl=7.83.1=h372c54d_0; cycler=0.11.0=pyhd8ed1ab_0; dask-core=2022.9.0=pyhd8ed1ab_0; dataclasses=0.8=pyhc8e2a94_3; datashader=0.14.2=py_0;
+  datashape=0.5.4=py_1; datrie=0.8.2=py310he24745e_3; debugpy=1.6.3=py310h154be8b_0; decorator=5.1.1=pyhd8ed1ab_0; defusedxml=0.7.1=pyhd8ed1ab_0;
+  docutils=0.19=py310h2ec42d9_0; dpath=2.0.6=py310h2ec42d9_1; dropbox=11.34.0=pyhd8ed1ab_0; entrypoints=0.4=pyhd8ed1ab_0;
+  executing=1.0.0=pyhd8ed1ab_0; expat=2.4.8=h96cf925_0; ffmpeg=4.3=h0a44026_0; filechunkio=1.8=py_2; filelock=3.8.0=pyhd8ed1ab_0;
+  firefox=104.0=hf0c8a7f_0; flit-core=3.7.1=pyhd8ed1ab_0; font-ttf-dejavu-sans-mono=2.37=hab24e00_0; font-ttf-inconsolata=3.000=h77eed37_0;
+  font-ttf-source-code-pro=2.038=h77eed37_0; font-ttf-ubuntu=0.83=hab24e00_0; fontconfig=2.14.0=h676cef8_0; fonts-conda-ecosystem=1=0;
+  fonts-conda-forge=1=0; fonttools=4.37.0=py310h90acd4f_0; freetype=2.12.1=h3f81eb7_0; fribidi=1.0.10=hbcb3906_0; frozenlist=1.3.1=py310h3c08dca_0;
+  fsspec=2022.8.2=pyhd8ed1ab_0; ftputil=5.0.4=pyhd8ed1ab_0; future=0.18.2=py310h2ec42d9_5; geckodriver=0.30.0=h04bdded_0;
+  geopandas-base=0.11.1=pyha770c72_0; geos=3.11.0=hb486fe8_0; geoviews=1.9.5=py_0; geoviews-core=1.9.5=py_0; gettext=0.19.8.1=hd1a6beb_1008;
+  gflags=2.2.2=hb1e8313_1004; gfortran_impl_osx-64=9.5.0=h2221f41_25; gfortran_osx-64=9.5.0=h18f7dce_0; git=2.37.3=pl5321hd164d3d_0;
+  gitdb=4.0.9=pyhd8ed1ab_0; gitpython=3.1.27=pyhd8ed1ab_0; glib=2.72.1=h2292cb8_0; glib-tools=2.72.1=h2292cb8_0; glog=0.6.0=h8ac2a54_0;
+  gmp=6.2.1=h2e338ed_0; gnutls=3.6.13=h756fd2b_1; google-api-core=2.10.0=pyhd8ed1ab_0; google-api-python-client=2.60.0=pyhd8ed1ab_0;
+  google-auth=2.11.0=pyh6c4a22f_0; google-auth-httplib2=0.1.0=pyhd8ed1ab_1; google-cloud-core=2.3.2=pyhd8ed1ab_0;
+  google-cloud-storage=2.5.0=pyh6c4a22f_0; google-crc32c=1.1.2=py310hf913535_3; google-resumable-media=2.3.3=pyhd8ed1ab_0;
+  googleapis-common-protos=1.56.4=py310h2ec42d9_0; graphite2=1.3.13=h2e338ed_1001; grpc-cpp=1.46.4=h6579160_7; grpcio=1.46.4=py310h082f274_7;
+  gsl=2.7=h93259b0_0; gst-plugins-base=1.20.3=h37e1711_1; gstreamer=1.20.3=h1d18e73_1; h11=0.13.0=pyhd8ed1ab_1; harfbuzz=5.1.0=h00bb2c2_0;
+  hdf4=4.2.15=h0623a88_4; hdf5=1.12.2=nompi_hc782337_100; holoviews=1.15.0=py_0; httplib2=0.20.4=pyhd8ed1ab_0; hvplot=0.8.1=py_0; icu=70.1=h96cf925_0;
+  idna=3.3=pyhd8ed1ab_0; importlib-metadata=4.11.4=py310h2ec42d9_0; importlib_metadata=4.11.4=hd8ed1ab_0; importlib_resources=5.9.0=pyhd8ed1ab_0;
+  iniconfig=1.1.1=pyh9f0ad1d_0; ipykernel=6.15.2=pyh736e0ef_0; ipython=8.5.0=pyhd1c38e8_1; ipython_genutils=0.2.0=py_1; ipywidgets=8.0.2=pyhd8ed1ab_1;
+  isl=0.22.1=hb1e8313_2; jedi=0.18.1=pyhd8ed1ab_2; jinja2=3.1.2=pyhd8ed1ab_1; jmespath=1.0.1=pyhd8ed1ab_0; jpeg=9e=hac89ed1_2;
+  json5=0.9.5=pyh9f0ad1d_0; jsonschema=4.15.0=pyhd8ed1ab_0; jupyter=1.0.0=py310h2ec42d9_7; jupyter_client=7.3.5=pyhd8ed1ab_0;
+  jupyter_console=6.4.4=pyhd8ed1ab_0; jupyter_core=4.11.1=py310h2ec42d9_0; jupyter_server=1.18.1=pyhd8ed1ab_0; jupyterlab=3.4.6=pyhd8ed1ab_0;
+  jupyterlab_pygments=0.2.2=pyhd8ed1ab_0; jupyterlab_server=2.15.1=pyhd8ed1ab_0; jupyterlab_widgets=3.0.3=pyhd8ed1ab_0;
+  kiwisolver=1.4.4=py310habb735a_0; krb5=1.19.3=hb49756b_0; lame=3.100=h35c211d_1001; lcms2=2.12=h577c468_0; ld64_osx-64=609=h1e06c2b_10;
+  lerc=4.0.0=hb486fe8_0; libabseil=20220623.0=cxx17_h844d122_3; libblas=3.9.0=16_osx64_mkl; libbrotlicommon=1.0.9=h5eb16cf_7;
+  libbrotlidec=1.0.9=h5eb16cf_7; libbrotlienc=1.0.9=h5eb16cf_7; libcblas=3.9.0=16_osx64_mkl; libclang=14.0.4=default_h55ffa42_0;
+  libclang-cpp14=14.0.4=default_h55ffa42_0; libclang13=14.0.4=default_hb5731bd_0; libcrc32c=1.1.2=he49afe7_0; libcurl=7.83.1=h372c54d_0;
+  libcxx=14.0.6=hccf4f1f_0; libdeflate=1.13=h775f41a_0; libedit=3.1.20191231=h0678c8f_2; libev=4.33=haf1e3a3_1; libevent=2.1.10=h815e4d9_4;
+  libffi=3.4.2=h0d85af4_5; libgfortran=5.0.0=10_4_0_h97931a8_25; libgfortran-devel_osx-64=9.5.0=hc2d6858_25; libgfortran5=11.3.0=h082f757_25;
+  libglib=2.72.1=hfbcb929_0; libgoogle-cloud=2.1.0=habe576c_1; libiconv=1.16=haf1e3a3_0; liblapack=3.9.0=16_osx64_mkl; liblapacke=3.9.0=16_osx64_mkl;
+  libllvm11=11.1.0=hd011deb_3; libllvm13=13.0.1=h64f94b2_2; libllvm14=14.0.4=h41df66c_0; libnetcdf=4.8.1=nompi_hebd45d5_104;
+  libnghttp2=1.47.0=h7cbc4dc_1; libogg=1.3.4=h35c211d_1; libopus=1.3.1=hc929b4f_1; libpng=1.6.37=h5481273_4; libpq=14.5=h76c7896_0;
+  libprotobuf=3.20.1=hbc0c0cd_4; libsodium=1.0.18=hbcb3906_1; libsqlite=3.39.3=ha978bb4_0; libssh2=1.10.0=h7535e13_3; libthrift=0.16.0=h9702cd6_1;
+  libtiff=4.4.0=h5e0c7b4_3; libutf8proc=2.7.0=h0d85af4_0; libuv=1.44.2=hac89ed1_0; libvorbis=1.3.7=h046ec9c_0; libwebp-base=1.2.4=h775f41a_0;
+  libxcb=1.13=h0d85af4_1004; libxml2=2.9.14=hea49891_4; libxslt=1.1.35=heaa0ce8_0; libzip=1.9.2=h3ad4413_1; libzlib=1.2.12=hfe4f2af_2;
+  llvm-openmp=14.0.4=ha654fa7_0; llvm-tools=14.0.4=h41df66c_0; llvmlite=0.38.1=py310h8fbb61a_0; locket=1.0.0=pyhd8ed1ab_0; logmuse=0.2.6=pyh8c360ce_0;
+  lxml=4.9.1=py310h6c45266_0; lz4-c=1.9.3=he49afe7_1; make=4.3=h22f3db7_1; markdown=3.4.1=pyhd8ed1ab_0; markupsafe=2.1.1=py310h1961e1f_1;
+  matplotlib=3.5.3=py310h2ec42d9_2; matplotlib-base=3.5.3=py310h1bfeb8c_2; matplotlib-inline=0.1.6=pyhd8ed1ab_0; mistune=2.0.4=pyhd8ed1ab_0;
+  mkl=2022.1.0=h860c996_928; mkl-devel=2022.1.0=h694c41f_929; mkl-include=2022.1.0=h6bab518_928; mpc=1.2.1=hbb51d92_0; mpfr=4.1.0=h0f52abe_1;
+  multidict=6.0.2=py310h1961e1f_1; multipledispatch=0.6.0=py_0; munkres=1.1.4=pyh9f0ad1d_0; mysql-common=8.0.30=h7ebae80_1;
+  mysql-libs=8.0.30=hc37e033_1; nbclassic=0.4.3=pyhd8ed1ab_0; nbclient=0.6.7=pyhd8ed1ab_0; nbconvert=7.0.0=pyhd8ed1ab_0;
+  nbconvert-core=7.0.0=pyhd8ed1ab_0; nbconvert-pandoc=7.0.0=pyhd8ed1ab_0; nbformat=5.4.0=pyhd8ed1ab_0; ncurses=6.3=h96cf925_1;
+  nest-asyncio=1.5.5=pyhd8ed1ab_0; netcdf4=1.6.0=nompi_py310h6892ea4_102; nettle=3.6=hedd7734_0; notebook=6.4.12=pyha770c72_0;
+  notebook-shim=0.1.0=pyhd8ed1ab_0; nspr=4.32=hcd9eead_1; nss=3.78=ha8197d3_0; numba=0.55.2=py310hab1bff6_0; numpy=1.22.4=py310hed37afb_0;
+  oauth2client=4.1.3=py_0; openh264=2.1.1=hfd3ada9_0; openjpeg=2.5.0=h5d0d7b0_1; openssl=1.1.1q=hfe4f2af_0; orc=1.7.6=hc067c44_0;
+  outcome=1.2.0=pyhd8ed1ab_0; packaging=21.3=pyhd8ed1ab_0; pandas=1.4.4=py310hecf8f37_0; pandoc=2.19.2=h694c41f_0; pandocfilters=1.5.0=pyhd8ed1ab_0;
+  panel=0.13.1=py_0; pango=1.50.9=hc8ec20f_0; param=1.12.2=py_0; paramiko=2.11.0=pyhd8ed1ab_0; parquet-cpp=1.5.1=2; parso=0.8.3=pyhd8ed1ab_0;
+  partd=1.3.0=pyhd8ed1ab_0; patsy=0.5.2=pyhd8ed1ab_0; pcre=8.45=he49afe7_0; pcre2=10.37=h3f55489_1; peppy=0.35.1=pyhd8ed1ab_0;
+  perl=5.32.1=2_h0d85af4_perl5; pexpect=4.8.0=pyh9f0ad1d_2; pickleshare=0.7.5=py_1003; pillow=9.2.0=py310h54af1cc_2; pip=22.2.2=pyhd8ed1ab_0;
+  pixman=0.40.0=hbcb3906_0; pkgutil-resolve-name=1.3.10=pyhd8ed1ab_0; plac=1.3.5=pyhd8ed1ab_0; pluggy=1.0.0=py310h2ec42d9_3; ply=3.11=py_1;
+  prettytable=3.4.1=pyhd8ed1ab_0; progress=1.6=pypi_0; proj=9.0.1=h05f0992_1; prometheus_client=0.14.1=pyhd8ed1ab_0;
+  prompt-toolkit=3.0.31=pyha770c72_0; prompt_toolkit=3.0.31=hd8ed1ab_0; protobuf=3.20.1=py310hd4537e4_0; psutil=5.9.2=py310h90acd4f_0;
+  pthread-stubs=0.4=hc929b4f_1001; ptyprocess=0.7.0=pyhd3deb0d_0; pulp=2.6.0=py310h2ec42d9_1; pure_eval=0.2.2=pyhd8ed1ab_0; py=1.11.0=pyh6c4a22f_0;
+  pyarrow=9.0.0=py310hf0faa4b_2_cpu; pyasn1=0.4.8=py_0; pyasn1-modules=0.2.7=py_0; pycparser=2.21=pyhd8ed1ab_0; pyct=0.4.8=py_0; pyct-core=0.4.8=py_0;
+  pygments=2.13.0=pyhd8ed1ab_0; pynacl=1.5.0=py310h1961e1f_1; pyopenssl=22.0.0=pyhd8ed1ab_0; pyparsing=3.0.9=pyhd8ed1ab_0;
+  pyproj=3.3.1=py310hac86e01_1; pyqt=5.15.7=py310h57cebac_0; pyqt5-sip=12.11.0=pypi_0; pyrsistent=0.18.1=py310h1961e1f_1; pysftp=0.2.9=py_1;
+  pyshp=2.3.1=pyhd8ed1ab_0; pysocks=1.7.1=pyha2e5f31_6; pytest=7.1.3=py310h2ec42d9_0; python=3.10.6=ha7b0be1_0_cpython;
+  python-dateutil=2.8.2=pyhd8ed1ab_0; python-fastjsonschema=2.16.1=pyhd8ed1ab_0; python-irodsclient=1.1.4=pyhd8ed1ab_0; python_abi=3.10=2_cp310;
+  pytorch=1.11.0=py3.10_0; pytz=2022.2.1=pyhd8ed1ab_0; pyu2f=0.1.5=pyhd8ed1ab_0; pyviz_comms=2.2.1=py_0; pyyaml=6.0=py310h1961e1f_4;
+  pyzmq=23.2.1=py310hcabbbd4_0; qt-main=5.15.4=h938c29d_2; qtconsole=5.3.2=pyhd8ed1ab_0; qtconsole-base=5.3.2=pyha770c72_0; qtpy=2.2.0=pyhd8ed1ab_0;
+  r-base=4.2.1=h85fa70c_1; ratelimiter=1.2.0=py_1002; re2=2022.06.01=hb486fe8_0; readline=8.1.2=h3899abd_0; requests=2.28.1=pyhd8ed1ab_1;
+  retry=0.9.2=py_0; rich=12.5.1=pyhd8ed1ab_0; rsa=4.9=pyhd8ed1ab_0; s3transfer=0.6.0=pyhd8ed1ab_0; sciencebasepy=2.0.4=pypi_0;
+  scipy=1.9.1=py310h240c617_0; seaborn=0.12.0=hd8ed1ab_0; seaborn-base=0.12.0=pyhd8ed1ab_0; selenium=4.4.0=pyhd8ed1ab_0;
+  send2trash=1.8.0=pyhd8ed1ab_0; setuptools=65.3.0=pyhd8ed1ab_1; setuptools-scm=7.0.5=pyhd8ed1ab_0; shapely=1.8.4=py310ha3038a0_0;
+  sigtool=0.1.3=h57ddcff_0; sip=6.6.2=py310hd4537e4_0; six=1.16.0=pyh6c4a22f_0; slacker=0.14.0=py_0; smart_open=6.1.0=pyha770c72_1;
+  smmap=3.0.5=pyh44b312d_0; snakemake=7.14.0=hdfd78af_0; snakemake-minimal=7.14.0=pyhdfd78af_0; snappy=1.1.9=h6e38e02_1; sniffio=1.3.0=pyhd8ed1ab_0;
+  sortedcontainers=2.4.0=pyhd8ed1ab_0; soupsieve=2.3.2.post1=pyhd8ed1ab_0; sqlite=3.39.3=h9ae0607_0; stack_data=0.5.0=pyhd8ed1ab_0;
+  statsmodels=0.13.2=py310h1bbcd0e_0; stone=3.3.1=pyhd8ed1ab_0; stopit=1.1.2=py_0; tabulate=0.8.10=pyhd8ed1ab_0; tapi=1100.0.11=h9ce4665_0;
+  tbb=2021.5.0=hb8565cd_2; terminado=0.15.0=py310h2ec42d9_0; tinycss2=1.1.1=pyhd8ed1ab_0; tk=8.6.12=h5dbffcc_0; tktable=2.10=h49f0cf7_3;
+  toml=0.10.2=pyhd8ed1ab_0; tomli=2.0.1=pyhd8ed1ab_0; toolz=0.12.0=pyhd8ed1ab_0; toposort=1.7=pyhd8ed1ab_0; torchaudio=0.11.0=py310_cpu;
+  torchvision=0.12.0=py310_cpu; tornado=6.2=py310h6c45266_0; tqdm=4.64.1=pyhd8ed1ab_0; traitlets=5.3.0=pyhd8ed1ab_0; trio=0.21.0=py310h2ec42d9_0;
+  trio-websocket=0.9.2=pyhd8ed1ab_0; typing-extensions=4.3.0=hd8ed1ab_0; typing_extensions=4.3.0=pyha770c72_0; tzdata=2022c=h191b570_0;
+  ubiquerg=0.6.2=pyhd8ed1ab_0; unicodedata2=14.0.0=py310h1961e1f_1; uritemplate=4.1.1=pyhd8ed1ab_0; urllib3=1.26.11=pyhd8ed1ab_0;
+  veracitools=0.1.3=py_0; wcwidth=0.2.5=pyh9f0ad1d_2; webencodings=0.5.1=py_1; websocket-client=1.4.1=pyhd8ed1ab_0; wheel=0.37.1=pyhd8ed1ab_0;
+  widgetsnbextension=4.0.3=pyhd8ed1ab_0; wrapt=1.14.1=py310h6c45266_0; wsproto=1.2.0=pyhd8ed1ab_0; xarray=2022.6.0=pyhd8ed1ab_1;
+  xorg-libxau=1.0.9=h35c211d_0; xorg-libxdmcp=1.1.3=h35c211d_0; xz=5.2.6=h775f41a_0; yaml=0.2.5=h0d85af4_2; yarl=1.7.2=py310h1961e1f_2;
+  yte=1.5.1=py310h2ec42d9_0; zeromq=4.3.4=he49afe7_1; zipp=3.8.1=pyhd8ed1ab_0; zlib=1.2.12=hfe4f2af_2; zstd=1.5.2=hfa58983_4;
+
+  Sixty percent of the available observational data were used to train the EA-LSTM, twenty percent were used for validation during training and
+  hyperparameter selection, and twenty percent were used to evaluate the final model's performance. Data were split by lake to avoid data leakage.
 
 distro-person: Joseph P. Nielsen
 liability-statement: >-

--- a/in_text/text_data_release.yml
+++ b/in_text/text_data_release.yml
@@ -171,9 +171,10 @@ process-description: >-
   of interest were derived from the daily temperature outputs for each lake.
   
   Lake temperature estimates were generated using an Entity-Aware Long Short-Term Memory network (EA-LSTM), as described by Kratzert et al., 2019.
-  The EA-LSTM network was trained on daily temperature observations from 15512 lakes. Inputs to the model were seven meteorological drivers derived
-  from NLDAS and four static lake attributes: latitude, longitude, surface area, and lake elevation above sea level. The data aggregation methods used
-  to assemble the temperature profile data and the lake attributes are described in Willard et al. 2022. This data release used these methods to
+  Temperature profiles were predicted for 82128 lakes in the North American continent from 1979 to 2022. The EA-LSTM network was trained on daily
+  temperature observations from 15512 lakes. Inputs to the model were seven meteorological drivers derived from NLDAS for the time period 1979-2022,
+  and four static lake attributes: latitude, longitude, surface area, and lake elevation above sea level. The data aggregation methods used to 
+  assemble the temperature profile data and the lake attributes are described in Willard et al. 2022. This data release used these methods to
   aggregate additional cooperator data. This data release also used full temperature profiles for each sampling date rather than only using surface
   temperatures.
   

--- a/in_text/text_data_release.yml
+++ b/in_text/text_data_release.yml
@@ -21,6 +21,12 @@ larger-cites:
 
 # ----supporting publications----    
 cross-cites:
+    authors: ['Kenneth E. Mitchell','Dag Lohmann','Paul R. Houser','Eric F. Wood','John C. Schaake','Alan Robock','Brian A. Cosgrove','Justin Sheffield','Qingyun Duan','Lifeng Luo','R. Wayne Higgins','Rachel T. Pinker','J. Dan Tarpley','Dennis P. Lettenmaier','Curtis H. Marshall','Jared K. Entin','Ming Pan','Wei Shi','Victor Koren','Jesse Meng','Bruce H. Ramsay','Andrew A. Bailey']
+    title: >-
+      The multi-institution North American Land Data Assimilation System (NLDAS): Utilizing multiple GCIP products and partners in a continental distributed hydrological modeling system
+    pubdate: 2004
+    form: publication
+    link: http://dx.doi.org/10.1029/2003JD003823
   -
     authors: ['Luke A. Winslow','Gretchen J.A. Hansen','Jordan S. Read','Michael Notaro']
     title: >-
@@ -40,6 +46,12 @@ cross-cites:
       Adam: A Method for Stochastic Optimization,
     pubdate: 2014
     link: https://doi.org/10.48550/arXiv.1412.6980
+  -
+    authors: ['Jared D. Willard', 'Jordan S. Read', 'Simon S. Topp', 'Gretchen J.A. Hansen', 'Vipin Kumar']
+    title: >-
+      Daily surface temperature predictions for 185,549 U.S. lakes with associated observations and meteorological conditions (1980-2020)
+    pubdate: 2022
+    link: https://doi.org/10.1002/lol2.10249
 
 process-date: !expr format(Sys.time(),'%Y%m%d')
 file-format: a single comma-delimited file and a single zipped shapefile
@@ -158,17 +170,25 @@ process-description: >-
   written or summarized to the files included in this set of data. In addition, a set of 172 annual metrics summarizing different thermal properties
   of interest were derived from the daily temperature outputs for each lake.
   
-  Lake temperature estimates were generated using an Entity-Aware Long Short-Term Memory network (EA-LSTM), as described by Kratzert et al., 2019. The
-  EA-LSTM network was trained on daily temperature observations from 15512 lakes. Temperature observations were organized into 400 day long sequences.
-  Successive sequences overlapped by 200 days. The mean squared error of the temperature predictions was used as a loss function. Predictions made
-  during the first 100 days were not included in the loss function. Inputs to the model were seven meteorological drivers derived from NLDAS and four
-  static lake attributes: latitude, longitude, surface area, and lake elevation above sea level.
+  Lake temperature estimates were generated using an Entity-Aware Long Short-Term Memory network (EA-LSTM), as described by Kratzert et al., 2019.
+  The EA-LSTM network was trained on daily temperature observations from 15512 lakes. Inputs to the model were seven meteorological drivers derived
+  from NLDAS and four static lake attributes: latitude, longitude, surface area, and lake elevation above sea level. The data aggregation methods used
+  to assemble the temperature profile data and the lake attributes are described in Willard et al. 2022. This data release used these methods to
+  aggregate additional cooperator data. This data release also used full temperature profiles for each sampling date rather than only using surface
+  temperatures.
+  
+  To train the EA-LSTM, temperature observations were organized into 400 day long sequences. Successive sequences overlapped by 200 days. The mean
+  squared error of the temperature predictions was used as a loss function. Predictions made during the first 100 days were not included in the loss
+  function. Sixty percent of the available observational data were used to train the EA-LSTM, twenty percent were used for validation during training
+  and hyperparameter selection, and twenty percent were used to evaluate the final model's performance. Data were split by lake to avoid data leakage.
   
   Lakes were discretized into a series of depth intervals. The top 10 meters of the lake were discretized into 0.5 m intervals. From 10 to 20 m, 1 m
   intervals were used. From 20 to 40 m, 2 m intervals were used. From 40 to 80 m, 5 m intervals were used. Observations were binned based on the
   discretized depth interval into which the depth of the observation fell. The EA-LSTM was trained to predict one temperature per depth interval at
   each time step. To allow temperature predictions at multiple depths, the number of outputs of the final fully connected layer was changed to equal
-  the number of depth intervals. The hidden layer size was 256. No dropout was used. The Adam optimizer (Kingma et al., 2015) was used with a learning
+  the number of depth intervals.
+  
+  The hidden layer size was 256. No dropout was used. The Adam optimizer (Kingma et al., 2015) was used with a learning
   rate of 0.005. Early stopping was used to determine the optimal number of training epochs with a stopping patience of 50 epochs.
   
   Modeling environment information for both modeling frameworks are captured below.
@@ -274,9 +294,6 @@ process-description: >-
   widgetsnbextension=4.0.3=pyhd8ed1ab_0; wrapt=1.14.1=py310h6c45266_0; wsproto=1.2.0=pyhd8ed1ab_0; xarray=2022.6.0=pyhd8ed1ab_1;
   xorg-libxau=1.0.9=h35c211d_0; xorg-libxdmcp=1.1.3=h35c211d_0; xz=5.2.6=h775f41a_0; yaml=0.2.5=h0d85af4_2; yarl=1.7.2=py310h1961e1f_2;
   yte=1.5.1=py310h2ec42d9_0; zeromq=4.3.4=he49afe7_1; zipp=3.8.1=pyhd8ed1ab_0; zlib=1.2.12=hfe4f2af_2; zstd=1.5.2=hfa58983_4;
-
-  Sixty percent of the available observational data were used to train the EA-LSTM, twenty percent were used for validation during training and
-  hyperparameter selection, and twenty percent were used to evaluate the final model's performance. Data were split by lake to avoid data leakage.
 
 distro-person: Joseph P. Nielsen
 liability-statement: >-

--- a/in_text/text_data_release.yml
+++ b/in_text/text_data_release.yml
@@ -171,8 +171,8 @@ process-description: >-
   of interest were derived from the daily temperature outputs for each lake.
   
   Lake temperature estimates were generated using an Entity-Aware Long Short-Term Memory network (EA-LSTM), as described by Kratzert et al., 2019.
-  Temperature profiles were predicted for 82128 lakes in the North American continent from 1979 to 2022. The EA-LSTM network was trained on daily
-  temperature observations from 15512 lakes. Inputs to the model were seven meteorological drivers derived from NLDAS for the time period 1979-2022,
+  Temperature profiles were predicted for 82128 lakes in the North American continent from 1979 to 2022. The EA-LSTM network used daily
+  temperature observations from 7556 lakes. Inputs to the model were seven meteorological drivers derived from NLDAS for the time period 1979-2022,
   and four static lake attributes: latitude, longitude, surface area, and lake elevation above sea level. The data aggregation methods used to 
   assemble the temperature profile data and the lake attributes are described in Willard et al. 2022. This data release used these methods to
   aggregate additional cooperator data. This data release also used full temperature profiles for each sampling date rather than only using surface


### PR DESCRIPTION
This PR adds a description of the process used to generate EA-LSTM temperature predictions, citations, and the Python environment for EA-LSTM. Text describing data aggregation borrowed from [here](https://github.com/padilla410/lake-temp-mo-data-release/blob/main/in_text/text_data_release.yml#L448-L453). Citations were mostly borrowed from [this list](https://github.com/padilla410/lake-temp-lstm-static-data-release/issues/10#issuecomment-1376377711). Fixes #6.